### PR TITLE
Change label name of "Current Tx Block" field to "Latest Tx Epoch"

### DIFF
--- a/src/components/HomePage/Dashboard/BCInfo/BCInfo.tsx
+++ b/src/components/HomePage/Dashboard/BCInfo/BCInfo.tsx
@@ -89,7 +89,7 @@ const BCInfo: React.FC = () => {
           ? <Container>
             <Row className='mb-3'>
               <Col>
-                <span className='subtext'>Current Tx Block:</span>
+                <span className='subtext'>Latest Tx Epoch:</span>
                 <br />
                 <span>{parseInt(data.NumTxBlocks).toLocaleString('en')}</span>
               </Col>

--- a/src/components/HomePage/Dashboard/BCInfo/BCInfo.tsx
+++ b/src/components/HomePage/Dashboard/BCInfo/BCInfo.tsx
@@ -89,7 +89,7 @@ const BCInfo: React.FC = () => {
           ? <Container>
             <Row className='mb-3'>
               <Col>
-                <span className='subtext'>Latest Tx Epoch:</span>
+                <span className='subtext'>Current Tx Epoch:</span>
                 <br />
                 <span>{parseInt(data.NumTxBlocks).toLocaleString('en')}</span>
               </Col>


### PR DESCRIPTION
## Description
Changed naming of `Current Tx Block` label in dashboard to `Latest Tx Epoch` with reference to below issue details
[https://github.com/Zilliqa/dev-explorer/issues/42](url)
Feel free to suggests if different naming is required.
![current_tx_epoch](https://user-images.githubusercontent.com/66236813/93418505-2460b580-f8dd-11ea-907e-5fd5bf9430f0.png)
