### PR TITLE
Bug when viewing error txn

### DIFF
--- a/src/components/Misc/Disp/AddressDisp/AddressDisp.tsx
+++ b/src/components/Misc/Disp/AddressDisp/AddressDisp.tsx
@@ -29,8 +29,14 @@ const AddressDisp: React.FC<IProps> = ({ addr, isLinked }) => {
     if (isValidAddr(addr)) {
       if (validation.isBech32(addr))
         setAddrPair([addr, fromBech32Address(addr).toLowerCase()])
-      else
-        setAddrPair([toBech32Address(addr), addr])
+      else {
+        try {
+          setAddrPair([toBech32Address(addr), addr])
+        }
+        catch(e) {
+          //Ignore the catch
+        }
+      }
     }
   }, [addr])
 


### PR DESCRIPTION
## Description:
Reference Issue : #44 
For the error transaction in the reference issue , address validation fails in sdk function `toBech32Address`.It thows exception to UI.
UI should ignore the error and should display the error transaction as well.
Added try catch to ignore exception.

Snapshot of error transaction:
**Txn Id**: 0xc04661bf037c9dc931554f93d186638db8525bafb4291826f98e46a3bb91f256

![Error_txn](https://user-images.githubusercontent.com/66236813/93556383-30b34400-f9ab-11ea-85bf-6062f8b0ffaa.png)
