### PR TITLE
Add viewblock redirect url icon to transaction

### DIFF
--- a/src/components/DetailsPages/TxnDetailsPage/TxnDetailsPage.css
+++ b/src/components/DetailsPages/TxnDetailsPage/TxnDetailsPage.css
@@ -1,3 +1,11 @@
+/* Header */
+
+.transaction-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
 /* Card */
 
 .txn-details-card {

--- a/src/components/DetailsPages/TxnDetailsPage/TxnDetailsPage.tsx
+++ b/src/components/DetailsPages/TxnDetailsPage/TxnDetailsPage.tsx
@@ -14,6 +14,7 @@ import { faExclamationCircle, faExchangeAlt, faFileContract } from '@fortawesome
 import InfoTabs, { generateTabsFromTxnDetails } from '../Misc/InfoTabs/InfoTabs'
 import LabelStar from '../Misc/LabelComponent/LabelStar'
 import NotFoundPage from '../../ErrorPages/NotFoundPage'
+import ViewBlockLink from '../Misc/ViewBlockLink/ViewBlockLink'
 
 import './TxnDetailsPage.css'
 
@@ -21,7 +22,7 @@ const TxnDetailsPage: React.FC = () => {
 
   const { txnHash } = useParams()
   const networkContext = useContext(NetworkContext)
-  const { dataService } = networkContext!
+  const { dataService, networkUrl } = networkContext!
 
   const [isLoading, setIsLoading] = useState<boolean>(false)
   const [error, setError] = useState<string | null>(null)
@@ -60,7 +61,7 @@ const TxnDetailsPage: React.FC = () => {
       ? <NotFoundPage />
       : data && data.txn.txParams.receipt && (
         <>
-          <div>
+          <div className='transaction-header'>
             <h3 className='mb-1'>
               <span className='mr-1'>
                 {(data.txn.txParams.receipt.success === undefined || data.txn.txParams.receipt.success)
@@ -72,6 +73,7 @@ const TxnDetailsPage: React.FC = () => {
               </span>
               <LabelStar type='Transaction' />
             </h3>
+            <ViewBlockLink network={networkUrl} type='tx' identifier={data.hash} />
           </div>
           <div className='subtext'>
             <HashDisp hash={'0x' + data.hash} />


### PR DESCRIPTION
## Description:

Reference Issue: #46 

Below is the snap of the change


**Transaction Page:**

![view_block_url](https://user-images.githubusercontent.com/66236813/93553585-ebd8de80-f9a5-11ea-8ca7-7613b3def90b.png)


**Redirected ViewBlock page:**

![actual_view_block_url](https://user-images.githubusercontent.com/66236813/93553644-1aef5000-f9a6-11ea-8ddc-7a34c3bf614b.png)
