### PR TITLE
Fix alignment issue happening with tx block component in recent devex deployment

### DIFF
--- a/src/components/HomePage/Dashboard/DisplayTable/DisplayTable.css
+++ b/src/components/HomePage/Dashboard/DisplayTable/DisplayTable.css
@@ -63,7 +63,7 @@
 /* Tx-Block List */
 
 .display-table #txheight-col {
-  width: 50px;
+  width: 60px;
 }
 
 .display-table #numTxns-col {

--- a/src/components/HomePage/Dashboard/DisplayTable/DisplayTable.css
+++ b/src/components/HomePage/Dashboard/DisplayTable/DisplayTable.css
@@ -67,7 +67,7 @@
 }
 
 .display-table #numTxns-col {
-  width: 60px;
+  width: 50px;
   text-align: center;
 }
 

--- a/src/components/HomePage/Dashboard/TxBlockList/TxBlockList.tsx
+++ b/src/components/HomePage/Dashboard/TxBlockList/TxBlockList.tsx
@@ -33,7 +33,7 @@ const TxBlockList: React.FC = () => {
     },
     {
       id: 'numTxns-col',
-      Header: 'Transactions',
+      Header: 'Txns',
       accessor: 'header.NumTxns',
       Cell: ({ value }: { value: string }) => (
         <div className='text-center'>{value}</div>


### PR DESCRIPTION
## Description,
Because of the addition of new column 'Txn Fees` ,  existing `Height` column got shrink.This causes block number not displaying fully.for eg:  123434...

Following changes are done.
1) `txheight-col` width increased from 50px to 60px.
2) Shortened the transaction column name to `Txns` and reduced width by 10 px.


![image](https://user-images.githubusercontent.com/66236813/93981021-f9310700-fdb1-11ea-8b31-1150a5eaa7fa.png)
