### PR TITLE
Populate "To" field  from tx params' "toAddr" address if receipt is false

### DIFF
--- a/src/components/DetailsPages/TxnDetailsPage/TxnDetailsPage.tsx
+++ b/src/components/DetailsPages/TxnDetailsPage/TxnDetailsPage.tsx
@@ -103,7 +103,9 @@ const TxnDetailsPage: React.FC = () => {
                               {' '}
                               {hexAddrToZilAddr(data.contractAddr)}
                             </QueryPreservingLink>
-                            : '-'
+                            : <QueryPreservingLink to={`/address/${hexAddrToZilAddr(data.txn.txParams.toAddr)}`}>
+                              {hexAddrToZilAddr(data.txn.txParams.toAddr)}
+                              </QueryPreservingLink>
                           : <QueryPreservingLink to={`/address/${hexAddrToZilAddr(data.txn.txParams.toAddr)}`}>
                             {hexAddrToZilAddr(data.txn.txParams.toAddr)}
                           </QueryPreservingLink>


### PR DESCRIPTION
## Description:
Issue Link #58 

Root cause:
Following transaction is an error transaction:
https://devex.zilliqa.com/tx/0x2b6852f1f8b8a224941b9ea85b925c073f2cd66c675d117a6190381046f7076d?network=https%3A%2F%2Fdev-api.zilliqa.com

Here the To address wasn't getting populated because `contractAddr` field is present and `receipt` parameter is false.

In existing code before the fix, if `contractAddr` field is present then we check if receipt is success or false.
If receipt is false then we display `-` instead of `toAddr` from the API.

`curl --request POST \
  --url https://dev-api.zilliqa.com/ \
  --header 'content-type: application/json' \
  --cookie __cfduid=d25391b951f70bde1c12e13c4594c9d541601009227 \
  --data '{
    "id": "1",
    "jsonrpc": "2.0",
    "method": "GetTransaction",
    "params": ["2b6852f1f8b8a224941b9ea85b925c073f2cd66c675d117a6190381046f7076d"]
}'`

