### PR TITLE
Display "no shards" if all shards are down

### DIFF
--- a/src/components/HomePage/Dashboard/BCInfo/BCInfo.tsx
+++ b/src/components/HomePage/Dashboard/BCInfo/BCInfo.tsx
@@ -106,7 +106,9 @@ const BCInfo: React.FC = () => {
               <Col>
                 <span className='subtext'>Sharding Structure:</span>
                 <br />
-                <span>[{data.ShardingStructure.NumPeers.toString()}]</span>
+                <span>[{data.ShardingStructure && data.ShardingStructure.NumPeers
+                      ? data.ShardingStructure.NumPeers.toString()
+                      : "no shards"}]</span>
               </Col>
             </Row>
             <Row className='mb-3'>


### PR DESCRIPTION
## Description:

**Issue link** #59 

**Problem**:
Tried to reproduce the issue by putting all shards down.The GUI couldn't be reloaded and below error is visible in console.

![image](https://user-images.githubusercontent.com/66236813/94781019-e25c6700-03e6-11eb-8fbb-9de210fea4f0.png)

**Fix**:
Handle the null reference and show "no shards" in GUI sharding structure field

![image](https://user-images.githubusercontent.com/66236813/94781246-2ea7a700-03e7-11eb-9202-9a8fcf4885d1.png)
