### PR TITLE
[develop] : zil-1742 Change Pending transactions fetch api call on UI

### DIFF
--- a/src/components/HomePage/Dashboard/DisplayTable/DisplayTable.tsx
+++ b/src/components/HomePage/Dashboard/DisplayTable/DisplayTable.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 import { useTable, HeaderGroup, Column, Row, Cell } from 'react-table'
 
 import { TransactionDetails } from 'src/typings/api'
-import { DsBlockObj, TxBlockObj, PendingTxnResult } from '@zilliqa-js/core/src/types'
+import { DsBlockObj, TxBlockObj, TransactionStatus } from '@zilliqa-js/core/src/types'
 
 import './DisplayTable.css'
 
@@ -12,9 +12,9 @@ interface IDisplayTableParams<T extends object> {
 }
 
 // React Table for DSBlocks, TxBlocks and TransactionDetails on Dashboard 
-const DisplayTable: React.FC<IDisplayTableParams<DsBlockObj | TxBlockObj | TransactionDetails | PendingTxnResult>> =
+const DisplayTable: React.FC<IDisplayTableParams<DsBlockObj | TxBlockObj | TransactionDetails | TransactionStatus>> =
   ({ columns, data }) => {
-    const { getTableProps, headerGroups, rows, prepareRow } = useTable<DsBlockObj | TxBlockObj | TransactionDetails | PendingTxnResult>({
+    const { getTableProps, headerGroups, rows, prepareRow } = useTable<DsBlockObj | TxBlockObj | TransactionDetails | TransactionStatus>({
       columns,
       data,
     })
@@ -23,7 +23,7 @@ const DisplayTable: React.FC<IDisplayTableParams<DsBlockObj | TxBlockObj | Trans
       <div className='display-table'>
         <table {...getTableProps()}>
           <thead>
-            {headerGroups.map((headerGroup: HeaderGroup<DsBlockObj | TxBlockObj | TransactionDetails | PendingTxnResult>) => (
+            {headerGroups.map((headerGroup: HeaderGroup<DsBlockObj | TxBlockObj | TransactionDetails | TransactionStatus>) => (
               <tr {...headerGroup.getHeaderGroupProps()} key={headerGroup.getHeaderGroupProps().key}>
                 {headerGroup.headers.map((column) => (
                   <th {...column.getHeaderProps()} key={column.getHeaderProps().key} id={column.id}>
@@ -34,11 +34,11 @@ const DisplayTable: React.FC<IDisplayTableParams<DsBlockObj | TxBlockObj | Trans
             ))}
           </thead>
           <tbody>
-            {rows.map((row: Row<DsBlockObj | TxBlockObj | TransactionDetails | PendingTxnResult>) => {
+            {rows.map((row: Row<DsBlockObj | TxBlockObj | TransactionDetails | TransactionStatus >) => {
               prepareRow(row)
               return (
                 <tr {...row.getRowProps()} key={row.getRowProps().key}>
-                  {row.cells.map((cell: Cell<DsBlockObj | TxBlockObj | TransactionDetails | PendingTxnResult>) => {
+                  {row.cells.map((cell: Cell<DsBlockObj | TxBlockObj | TransactionDetails | TransactionStatus>) => {
                     return (
                       <td {...cell.getCellProps()}
                         key={cell.getCellProps().key}>

--- a/src/components/HomePage/Dashboard/PendTxnList/PendTxnList.tsx
+++ b/src/components/HomePage/Dashboard/PendTxnList/PendTxnList.tsx
@@ -4,7 +4,7 @@ import CustomScroll from 'react-custom-scroll'
 
 import { refreshRate } from 'src/constants'
 import { NetworkContext } from 'src/services/network/networkProvider'
-import { PendingTxnResultWithHash } from 'src/typings/api'
+import { TransactionStatus } from '@zilliqa-js/core/src/types'
 
 import DisplayTable from '../DisplayTable/DisplayTable'
 
@@ -18,13 +18,13 @@ const PendTxnList: React.FC = () => {
 
   useEffect(() => { setData(null) }, [networkUrl]) // Unset data on url change
 
-  const [data, setData] = useState<PendingTxnResultWithHash[] | null>(null)
+  const [data, setData] = useState<TransactionStatus[] | null>(null)
 
   const columns = useMemo(
     () => [{
       id: 'pend-hash-col',
       Header: 'Hash',
-      accessor: 'hash',
+      accessor: 'TxnHash',
       Cell: ({ value }: { value: string }) => (
         <div className='mono'>{'0x' + value}</div>
       )
@@ -52,7 +52,7 @@ const PendTxnList: React.FC = () => {
     let isCancelled = false
     if (!dataService) return
 
-    let receivedData: PendingTxnResultWithHash[]
+    let receivedData: TransactionStatus[]
     const getData = async () => {
       try {
         receivedData = await dataService.getLatest5PendingTransactions()

--- a/src/components/ViewAllPages/ViewAllTable/ViewAllTable.tsx
+++ b/src/components/ViewAllPages/ViewAllTable/ViewAllTable.tsx
@@ -3,7 +3,7 @@ import { Pagination, Row as BRow, Col as BCol, Spinner } from 'react-bootstrap'
 import { useTable, HeaderGroup, Column, Row, Cell, usePagination, useAsyncDebounce } from 'react-table'
 
 import { TransactionDetails } from 'src/typings/api'
-import { DsBlockObj, TxBlockObj, PendingTxnResult } from '@zilliqa-js/core/src/types'
+import { DsBlockObj, TxBlockObj} from '@zilliqa-js/core/src/types'
 
 import './ViewAllTable.css'
 
@@ -15,7 +15,7 @@ interface IViewAllTableParams<T extends object> {
   pageCount: number,
 }
 
-const ViewAllTable: React.FC<IViewAllTableParams<DsBlockObj | TxBlockObj | TransactionDetails | PendingTxnResult>> =
+const ViewAllTable: React.FC<IViewAllTableParams<DsBlockObj | TxBlockObj | TransactionDetails>> =
   ({ columns, data, isLoading, fetchData, pageCount: controlledPageCount }) => {
 
     const { getTableProps,
@@ -30,7 +30,7 @@ const ViewAllTable: React.FC<IViewAllTableParams<DsBlockObj | TxBlockObj | Trans
       nextPage,
       previousPage,
       // Get the state from the instance
-      state: { pageIndex } } = useTable<DsBlockObj | TxBlockObj | TransactionDetails | PendingTxnResult>({
+      state: { pageIndex } } = useTable<DsBlockObj | TxBlockObj | TransactionDetails>({
         columns,
         data,
         initialState: { pageIndex: 0 },
@@ -103,7 +103,7 @@ const ViewAllTable: React.FC<IViewAllTableParams<DsBlockObj | TxBlockObj | Trans
           {isLoading ? <div className='center-spinner mt-4'><Spinner animation="border" /></div> : null}
           <table {...getTableProps()}>
             <thead>
-              {headerGroups.map((headerGroup: HeaderGroup<DsBlockObj | TxBlockObj | TransactionDetails | PendingTxnResult>) => (
+              {headerGroups.map((headerGroup: HeaderGroup<DsBlockObj | TxBlockObj | TransactionDetails>) => (
                 <tr {...headerGroup.getHeaderGroupProps()} key={headerGroup.getHeaderGroupProps().key} >
                   {headerGroup.headers.map((column) => (
                     <th {...column.getHeaderProps()} key={column.getHeaderProps().key} id={column.id}>
@@ -114,11 +114,11 @@ const ViewAllTable: React.FC<IViewAllTableParams<DsBlockObj | TxBlockObj | Trans
               ))}
             </thead>
             <tbody style={isLoading ? { opacity: '0.5' } : {}}{...getTableBodyProps()}>
-              {page.map((row: Row<DsBlockObj | TxBlockObj | TransactionDetails | PendingTxnResult>) => {
+              {page.map((row: Row<DsBlockObj | TxBlockObj | TransactionDetails>) => {
                 prepareRow(row)
                 return (
                   <tr {...row.getRowProps()} key={row.getRowProps().key}>
-                    {row.cells.map((cell: Cell<DsBlockObj | TxBlockObj | TransactionDetails | PendingTxnResult>) => {
+                    {row.cells.map((cell: Cell<DsBlockObj | TxBlockObj | TransactionDetails>) => {
                       return (
                         <td {...cell.getCellProps()}
                           key={cell.getCellProps().key}>

--- a/src/services/network/dataService.tsx
+++ b/src/services/network/dataService.tsx
@@ -24,7 +24,7 @@
   4) getTransactionsForTxBlock(blockNum: number): Promise<string[]>
   5) getTransactionsDetails(txnHashes: string[]): Promise<TransactionDetails[]>
   6) getRecentTransactions(): Promise<TxList>
-  7) getLatest5PendingTransactions(): Promise<PendingTxnResultWithHash[]>
+  7) getLatest5PendingTransactions(): Promise<TransactionStatus[]>
 
   Account-related:
   1) getAccData(accAddr: string): Promise<AccData>
@@ -52,11 +52,11 @@
 
 import { Zilliqa } from '@zilliqa-js/zilliqa'
 import { ContractObj } from '@zilliqa-js/contract/src/types'
-import { BlockchainInfo, DsBlockObj, TxBlockObj, TxList, MinerInfo, TransactionObj } from '@zilliqa-js/core/src/types'
+import { BlockchainInfo, DsBlockObj, TxBlockObj, TxList, MinerInfo, TransactionObj,TransactionStatus } from '@zilliqa-js/core/src/types'
 
 import {
   DsBlockObjWithHashListing, TxBlockObjListing, TransactionDetails, ContractData,
-  AccData, DsBlockObjWithHash, PendingTxnResultWithHash, IISInfo
+  AccData, DsBlockObjWithHash, IISInfo
 } from 'src/typings/api'
 import { hexAddrToZilAddr, stripHexPrefix } from 'src/utils/Utils'
 
@@ -282,19 +282,10 @@ export class DataService {
     return response.result as TxList
   }
 
-  async getLatest5PendingTransactions(): Promise<PendingTxnResultWithHash[]> {
+  async getLatest5PendingTransactions(): Promise<TransactionStatus[]> {
     console.log("getting 5 pending tx")
     const pendingTxns = await this.zilliqa.blockchain.getPendingTxns()
-    const txnHashes = pendingTxns.Txns.map((x) => x.TxnHash)
-    const output = await Promise.all(
-      txnHashes.map(async (txnHash: string) => {
-        const pendingTxn = await this.zilliqa.blockchain.getPendingTxn(txnHash)
-        return {
-          ...pendingTxn,
-          hash: txnHash,
-        } as PendingTxnResultWithHash
-      }))
-    return output as PendingTxnResultWithHash[]
+    return pendingTxns.Txns as TransactionStatus[]
   }
 
   //================================================================================

--- a/src/typings/api.d.ts
+++ b/src/typings/api.d.ts
@@ -2,7 +2,7 @@
   built on top of Zilliqa's Javascript SDK */
 import { Transaction } from '@zilliqa-js/account/src/transaction'
 import { Value } from '@zilliqa-js/contract/src/types'
-import { PendingTxnResult, DsBlockObj, TxBlockObj } from '@zilliqa-js/core/src/types'
+import { DsBlockObj, TxBlockObj } from '@zilliqa-js/core/src/types'
 
 export interface DsBlockObjWithHash extends DsBlockObj {
   Hash: string
@@ -34,10 +34,6 @@ export interface ContractData {
 export interface AccData {
   balance: string,
   nonce: string,
-}
-
-export interface PendingTxnResultWithHash extends PendingTxnResult {
-  hash: string
 }
 
 export interface IISInfo {


### PR DESCRIPTION

## Description
It's been observed in one of the mainnet rehearsal testing that Pending Transactions display takes long time to populate on UI.
In the existing implementation, `GetPendingTxns` is called first which returns the list of pending txns. The code loop through individual txn and populate UI with `Hash`, `Code`, `Description` params. This may take long time if the list is long, say 100 or more txns. For eg : Consider we have 10 pending txns, then total api calls would be 1(GetPendingTxns) + 10(GetPendingTxn) = 11

## Fix
The second api call- GetPendingTxn on individual txn is not required as we have above three fields returned by zilliqa-js api in `GetPendingTxns` call.